### PR TITLE
Add codiceIPA

### DIFF
--- a/publiccode.yml
+++ b/publiccode.yml
@@ -104,6 +104,8 @@ intendedAudience:
   countries:
     - it
 it:
+  riuso:
+    codiceIPA: c_a182
   conforme:
     gdpr: true
     lineeGuidaDesign: true


### PR DESCRIPTION
Buongiorno @EuroServizi @ComunediAlessandria,
la seguente PR:
* aggiunge il campo codiceIPA al file publiccode.yml

In tal modo sarà possibile indicizzare correttamente il software all'interno del catalogo del riuso.
Resto a disposizione, grazie per l'attenzione.
